### PR TITLE
Return error message with 400 status code

### DIFF
--- a/gabi-cli.go
+++ b/gabi-cli.go
@@ -162,7 +162,7 @@ func queryGabi(url, query, token string) (models.QueryResponse, error) {
 	}
 
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusBadRequest {
 		return models.QueryResponse{}, fmt.Errorf("http status: %s", resp.Status)
 	}
 


### PR DESCRIPTION
Example
```
> select asdf;
Error: ERROR: column "asdf" does not exist (SQLSTATE 42703)
```